### PR TITLE
Stripe: accept multiple v1 signatures in Stripe-Signature header

### DIFF
--- a/hmac-verify.js
+++ b/hmac-verify.js
@@ -43,24 +43,43 @@ function verifyGitHubSignature({ secret, payload, signatureHeader }) {
 }
 
 /**
+ * Parse Stripe header.
+ * - Header: "Stripe-Signature: t=<unix>,v1=<hexdigest>[,v0=...,v1=...]"
+ * - Returns { t, v1s } where v1s is an array of all v1 signature hex strings.
+ */
+function parseStripeHeader(headerValue) {
+  if (!headerValue) return null;
+
+  // Split by commas into key=value pairs, but only on the first '=' per pair.
+  const kvs = String(headerValue)
+    .split(",")
+    .map((kv) => {
+      const [k, ...rest] = kv.split("=");
+      return [k.trim(), rest.join("=").trim()];
+    });
+
+  // Collect non-v1 entries into 'parts' and all v1 values into 'v1s'
+  const parts = Object.fromEntries(kvs.filter(([k]) => k !== "v1"));
+  const v1s = kvs
+    .filter(([k]) => k === "v1")
+    .map(([, v]) => v)
+    .filter(Boolean);
+
+  if (!parts.t || v1s.length === 0) return null;
+
+  const t = Number(parts.t);
+  if (!Number.isFinite(t)) return null;
+
+  return { t, v1s };
+}
+
+/**
  * Verify a Stripe-style webhook.
  * - Header: "Stripe-Signature: t=<unix>,v1=<hexdigest>[,v0=...,v1=...]"
  * - Signed payload is: `${t}.${rawBody}`
  * - Reject if timestamp is too old (default 5 min).
+ * - Accept if ANY provided v1 matches (Stripe can send multiple).
  */
-function parseStripeHeader(headerValue) {
-  if (!headerValue) return null;
-  const parts = Object.fromEntries(
-    String(headerValue)
-      .split(",")
-      .map((kv) => kv.split("=").map((s) => s.trim()))
-  );
-  if (!parts.t || !parts.v1) return null;
-  const t = Number(parts.t);
-  if (!Number.isFinite(t)) return null;
-  return { t, v1: parts.v1 };
-}
-
 function verifyStripeSignature({
   secret,
   payload,
@@ -75,13 +94,19 @@ function verifyStripeSignature({
   const skew = Math.abs(nowSec() - parsed.t);
   if (skew > toleranceSec) return false;
 
-  const signed = `${parsed.t}.${Buffer.isBuffer(payload) ? payload.toString("utf8") : String(payload)}`;
-  return verifyHmac({
-    algo: "sha256",
-    secret,
-    payload: signed,
-    expected: parsed.v1,
-  });
+  const signed = `${parsed.t}.${
+    Buffer.isBuffer(payload) ? payload.toString("utf8") : String(payload)
+  }`;
+
+  // Accept if ANY v1 matches
+  return parsed.v1s.some((v1) =>
+    verifyHmac({
+      algo: "sha256",
+      secret,
+      payload: signed,
+      expected: v1,
+    })
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
Stripe may include multiple v1 signatures in the header. This change parses all v1 values and accepts if any match. Also hardens header parsing when values contain =. Includes no behavior changes outside Stripe verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Stripe webhook signature handling now supports multiple v1 signatures in the header. Verification succeeds if any valid signature matches, improving compatibility during key rotations and reducing false negatives.
- Documentation
  - Updated guidance to reflect multi-signature header handling and verification behavior.
- Notes
  - If your integration consumes parsed webhook headers directly, be aware the header may include multiple v1 signatures rather than a single value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->